### PR TITLE
Improve the Stats Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ cmake --build .
 ```
 > quicreach --help
 usage: quicreach <hostname(s)> [options...]
- -a, --alpn         The ALPN to use for the handshake (def=h3)
- -h, --help         Prints this help text
- -p, --port <port>  The default UDP port to use
- -s, --stats        Print connection statistics
- -u, --unsecure     Allows unsecure connections
+ -a, --alpn <alpn>      The ALPN to use for the handshake (def=h3)
+ -b, --built-in-val     Use built-in TLS validation logic
+ -h, --help             Prints this help text
+ -p, --port <port>      The default UDP port to use
+ -r, --req-all          Require all hostnames to succeed
+ -s, --stats            Print connection statistics
+ -u, --unsecure         Allows unsecure connections
 ```
 
 ```
@@ -50,16 +52,16 @@ Failure
 
 ```Bash
 > quicreach '*' --stats
-                        SERVER          TIME           RTT    SEND:RECV           STATS
-               quic.aiortc.org    209.917 ms     99.328 ms    1242:4880 (3.9x)    4545 RX CRYPTO
-              ietf.akaquic.com
+                        SERVER           RTT        TIME_I        TIME_H           SEND:RECV      C1      S1
+               quic.aiortc.org     68.545 ms     73.855 ms    143.703 ms    2440:4898 (2.0x)     274    4545
+              ietf.akaquic.com     89.399 ms     92.660 ms    182.458 ms    2440:5850 (2.4x)     275    4565
                  quic.ogre.com
                     quic.rocks
-                       mew.org    428.800 ms    212.446 ms    1284:6650 (5.2x)    4541 RX CRYPTO
+                       mew.org    177.611 ms    177.872 ms    352.459 ms    2440:6750 (2.8x)     266    4541
   http3-test.litespeedtech.com
-                    msquic.net    147.155 ms     75.131 ms    1263:3729 (3.0x)    3461 RX CRYPTO
-                   nghttp2.org
-           cloudflare-quic.com     27.666 ms     14.006 ms    1200:5130 (4.3x)    2668 RX CRYPTO
+                    msquic.net     67.373 ms     67.735 ms    130.850 ms    2440:3729 (1.5x)     269    3461
+                   nghttp2.org    158.051 ms    158.364 ms    314.771 ms    2440:4542 (1.9x)     270    4173
+           cloudflare-quic.com      1.958 ms      5.841 ms      6.548 ms    1220:5129 (4.2x)     278    2667
           pandora.cm.in.tum.de
 ```
 

--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -40,12 +40,13 @@ struct ReachConfig {
 bool ParseConfig(int argc, char **argv, ReachConfig& Config) {
     if (argc < 2 || !strcmp(argv[1], "-?") || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
         printf("usage: quicreach <hostname(s)> [options...]\n"
-               " -a, --alpn         The ALPN to use for the handshake (def=h3)\n"
-               " -h, --help         Prints this help text\n"
-               " -p, --port <port>  The default UDP port to use\n"
-               " -r, --req-all      Require all hostnames to suceed\n"
-               " -s, --stats        Print connection statistics\n"
-               " -u, --unsecure     Allows unsecure connections\n"
+               " -a, --alpn <alpn>            The ALPN to use for the handshake (def=h3)\n"
+               " -b, --built-in-validation    Use built-in TLS validation logic\n"
+               " -h, --help                   Prints this help text\n"
+               " -p, --port <port>            The default UDP port to use\n"
+               " -r, --req-all                Require all hostnames to suceed\n"
+               " -s, --stats                  Print connection statistics\n"
+               " -u, --unsecure               Allows unsecure connections\n"
               );
         return false;
     }

--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -40,13 +40,13 @@ struct ReachConfig {
 bool ParseConfig(int argc, char **argv, ReachConfig& Config) {
     if (argc < 2 || !strcmp(argv[1], "-?") || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
         printf("usage: quicreach <hostname(s)> [options...]\n"
-               " -a, --alpn <alpn>            The ALPN to use for the handshake (def=h3)\n"
-               " -b, --built-in-validation    Use built-in TLS validation logic\n"
-               " -h, --help                   Prints this help text\n"
-               " -p, --port <port>            The default UDP port to use\n"
-               " -r, --req-all                Require all hostnames to succeed\n"
-               " -s, --stats                  Print connection statistics\n"
-               " -u, --unsecure               Allows unsecure connections\n"
+               " -a, --alpn <alpn>      The ALPN to use for the handshake (def=h3)\n"
+               " -b, --built-in-val     Use built-in TLS validation logic\n"
+               " -h, --help             Prints this help text\n"
+               " -p, --port <port>      The default UDP port to use\n"
+               " -r, --req-all          Require all hostnames to succeed\n"
+               " -s, --stats            Print connection statistics\n"
+               " -u, --unsecure         Allows unsecure connections\n"
               );
         return false;
     }
@@ -72,7 +72,7 @@ bool ParseConfig(int argc, char **argv, ReachConfig& Config) {
         if (!strcmp(argv[i], "--alpn") || !strcmp(argv[i], "-a")) {
             if (++i >= argc) { printf("Missing ALPN string\n"); return false; }
             Config.Alpn = argv[i];
-        } else if (!strcmp(argv[i], "--built-in-validation") || !strcmp(argv[i], "-b")) {
+        } else if (!strcmp(argv[i], "--built-in-val") || !strcmp(argv[i], "-b")) {
             Config.CredFlags |= QUIC_CREDENTIAL_FLAG_USE_TLS_BUILTIN_CERTIFICATE_VALIDATION;
         } else if (!strcmp(argv[i], "--port") || !strcmp(argv[i], "-p")) {
             if (++i >= argc) { printf("Missing port number\n"); return false; }

--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -71,6 +71,8 @@ bool ParseConfig(int argc, char **argv, ReachConfig& Config) {
         if (!strcmp(argv[i], "--alpn") || !strcmp(argv[i], "-a")) {
             if (++i >= argc) { printf("Missing ALPN string\n"); return false; }
             Config.Alpn = argv[i];
+        } else if (!strcmp(argv[i], "--built-in-validation") || !strcmp(argv[i], "-b")) {
+            Config.CredFlags |= QUIC_CREDENTIAL_FLAG_USE_TLS_BUILTIN_CERTIFICATE_VALIDATION;
         } else if (!strcmp(argv[i], "--port") || !strcmp(argv[i], "-p")) {
             if (++i >= argc) { printf("Missing port number\n"); return false; }
             Config.Port = (uint16_t)atoi(argv[i]);
@@ -128,7 +130,7 @@ bool TestReachability(const ReachConfig& Config) {
     if (!Configuration.IsValid()) { printf("Configuration initializtion failed!\n"); return false; }
 
     if (Config.PrintStatistics)
-        printf("%30s          TIME           RTT    SEND:RECV           STATS\n", "SERVER");
+        printf("%30s           RTT        TIME_I        TIME_H           SEND:RECV      C1      S1\n", "SERVER");
 
     uint32_t ReachableCount = 0;
     for (auto HostName : Config.HostNames) {
@@ -141,15 +143,18 @@ bool TestReachability(const ReachConfig& Config) {
 
         Connection.WaitOnHandshakeComplete();
         if (Connection.HandshakeSuccess) {
-            auto Time = (uint32_t)(Connection.Stats.TimingHandshakeFlightEnd - Connection.Stats.TimingStart);
-            auto Amplication = (double)Connection.Stats.RecvTotalBytes / (double)Connection.Stats.SendTotalBytes;
+            auto HandshakeTime = (uint32_t)(Connection.Stats.TimingHandshakeFlightEnd - Connection.Stats.TimingStart);
+            auto InitialTime = (uint32_t)(Connection.Stats.TimingInitialFlightEnd - Connection.Stats.TimingStart);
+            auto Amplification = (double)Connection.Stats.RecvTotalBytes / (double)Connection.Stats.SendTotalBytes;
             if (Config.PrintStatistics)
-                printf("    %3u.%03u ms    %3u.%03u ms    %u:%u (%2.1fx)    %u RX CRYPTO",
-                        Time / 1000, Time % 1000,
+                printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u (%2.1fx)    %4u    %4u",
                         Connection.Stats.Rtt / 1000, Connection.Stats.Rtt % 1000,
+                        InitialTime / 1000, InitialTime % 1000,
+                        HandshakeTime / 1000, HandshakeTime % 1000,
                         (uint32_t)Connection.Stats.SendTotalBytes,
                         (uint32_t)Connection.Stats.RecvTotalBytes,
-                        Amplication,
+                        Amplification,
+                        Connection.Stats.HandshakeClientFlight1Bytes,
                         Connection.Stats.HandshakeServerFlight1Bytes);
             ++ReachableCount;
         }

--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -44,7 +44,7 @@ bool ParseConfig(int argc, char **argv, ReachConfig& Config) {
                " -b, --built-in-validation    Use built-in TLS validation logic\n"
                " -h, --help                   Prints this help text\n"
                " -p, --port <port>            The default UDP port to use\n"
-               " -r, --req-all                Require all hostnames to suceed\n"
+               " -r, --req-all                Require all hostnames to succeed\n"
                " -s, --stats                  Print connection statistics\n"
                " -u, --unsecure               Allows unsecure connections\n"
               );


### PR DESCRIPTION
New output format:
```
$ quicreach google.com,msquic.net,cloudflare.com,facebook.com,youtube.com --stats
                        SERVER           RTT        TIME_I        TIME_H           SEND:RECV      C1      S1
                    google.com      3.021 ms      3.302 ms      6.925 ms    2440:8224 (3.4x)     269    6799
                    msquic.net     68.845 ms     69.248 ms    133.980 ms    2440:3729 (1.5x)     269    3461
                cloudflare.com      1.782 ms      3.571 ms      4.355 ms    1220:5157 (4.2x)     273    2695
                  facebook.com      1.801 ms      3.053 ms      3.528 ms    1220:4483 (3.7x)     271    3219
                   youtube.com      2.628 ms      2.813 ms      5.478 ms    2440:8217 (3.4x)     270    6791

5 domains reachable
```
Also added `--built-in-val` option:
```
$ quicreach --help
usage: quicreach <hostname(s)> [options...]
 -a, --alpn <alpn>      The ALPN to use for the handshake (def=h3)
 -b, --built-in-val     Use built-in TLS validation logic
 -h, --help             Prints this help text
 -p, --port <port>      The default UDP port to use
 -r, --req-all          Require all hostnames to succeed
 -s, --stats            Print connection statistics
 -u, --unsecure         Allows unsecure connections
```