### PR TITLE
Print Stats on Handshake issues

### DIFF
--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -148,12 +148,12 @@ bool TestReachability(const ReachConfig& Config) {
             auto InitialTime = (uint32_t)(Connection.Stats.TimingInitialFlightEnd - Connection.Stats.TimingStart);
             auto Amplification = (double)Connection.Stats.RecvTotalBytes / (double)Connection.Stats.SendTotalBytes;
             auto TooMuch = false, MultiRtt = false;
-            if ((HandshakeTime - InitialTime) < Connection.Stats.Rtt) {
-                TooMuch = Amplification > 3.0;
-                if (TooMuch) ++TooMuchCount;
-            } else {
+            if (HandshakeTime >= 1.8 * Connection.Stats.MinRtt) {
                 MultiRtt = true;
                 ++MultiRttCount;
+            } else {
+                TooMuch = Amplification > 3.0;
+                if (TooMuch) ++TooMuchCount;
             }
             if (Config.PrintStatistics)
                 printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u (%2.1fx)    %4u    %4u    %c",
@@ -175,7 +175,7 @@ bool TestReachability(const ReachConfig& Config) {
         if (ReachableCount > 1) {
             printf("\n%u domains reachable\n", ReachableCount);
             if (TooMuchCount)
-                printf("(!) %u domain(s) exceed amplification limits\n", TooMuchCount);
+                printf("(!) %u domain(s) exceeded amplification limits\n", TooMuchCount);
             if (MultiRttCount)
                 printf("(*) %u domain(s) required multiple round trips\n", MultiRttCount);
         }

--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -133,7 +133,7 @@ bool TestReachability(const ReachConfig& Config) {
     if (Config.PrintStatistics)
         printf("%30s           RTT        TIME_I        TIME_H           SEND:RECV      C1      S1\n", "SERVER");
 
-    uint32_t ReachableCount = 0;
+    uint32_t ReachableCount = 0, TooMuchCount = 0, MultiRttCount = 0;
     for (auto HostName : Config.HostNames) {
         if (Config.PrintStatistics) printf("%30s", HostName);
         ReachConnection Connection(Registration);
@@ -147,8 +147,16 @@ bool TestReachability(const ReachConfig& Config) {
             auto HandshakeTime = (uint32_t)(Connection.Stats.TimingHandshakeFlightEnd - Connection.Stats.TimingStart);
             auto InitialTime = (uint32_t)(Connection.Stats.TimingInitialFlightEnd - Connection.Stats.TimingStart);
             auto Amplification = (double)Connection.Stats.RecvTotalBytes / (double)Connection.Stats.SendTotalBytes;
+            auto TooMuch = false, MultiRtt = false;
+            if ((HandshakeTime - InitialTime) < Connection.Stats.Rtt) {
+                TooMuch = Amplification > 3.0;
+                if (TooMuch) ++TooMuchCount;
+            } else {
+                MultiRtt = true;
+                ++MultiRttCount;
+            }
             if (Config.PrintStatistics)
-                printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u (%2.1fx)    %4u    %4u",
+                printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u (%2.1fx)    %4u    %4u    %c",
                         Connection.Stats.Rtt / 1000, Connection.Stats.Rtt % 1000,
                         InitialTime / 1000, InitialTime % 1000,
                         HandshakeTime / 1000, HandshakeTime % 1000,
@@ -156,14 +164,22 @@ bool TestReachability(const ReachConfig& Config) {
                         (uint32_t)Connection.Stats.RecvTotalBytes,
                         Amplification,
                         Connection.Stats.HandshakeClientFlight1Bytes,
-                        Connection.Stats.HandshakeServerFlight1Bytes);
+                        Connection.Stats.HandshakeServerFlight1Bytes,
+                        TooMuch ? '!' : (MultiRtt ? '*' : ' '));
             ++ReachableCount;
         }
         if (Config.PrintStatistics) printf("\n");
     }
 
-    if (Config.PrintStatistics && ReachableCount > 1)
-        printf("\n%u domains reachable\n", ReachableCount);
+    if (Config.PrintStatistics) {
+        if (ReachableCount > 1) {
+            printf("\n%u domains reachable\n", ReachableCount);
+            if (TooMuchCount)
+                printf("(!) %u domain(s) exceed amplification limits\n", TooMuchCount);
+            if (MultiRttCount)
+                printf("(*) %u domain(s) required multiple round trips\n", MultiRttCount);
+        }
+    }
     return Config.RequireAll ? ((size_t)ReachableCount == Config.HostNames.size()) : (ReachableCount != 0);
 }
 


### PR DESCRIPTION
Prints stats on issues found with the handshakes:
```
$ quicreach google.com,msquic.net,cloudflare.com,facebook.com,youtube.com --stats
                        SERVER           RTT        TIME_I        TIME_H           SEND:RECV      C1      S1
                    google.com      2.474 ms      2.727 ms      5.396 ms    2440:8229 (3.4x)     269    6801    *
                    msquic.net     66.376 ms     66.793 ms    131.323 ms    2440:3729 (1.5x)     269    3461    *
                cloudflare.com      2.276 ms      4.081 ms      5.338 ms    1220:5157 (4.2x)     273    2695    *
                  facebook.com      2.143 ms      4.317 ms      5.062 ms    1220:4482 (3.7x)     271    3218    *
                   youtube.com      2.236 ms      2.414 ms      5.171 ms    2440:8224 (3.4x)     270    6800    *

5 domains reachable
(*) 5 domain(s) required multiple round trips
```