### PR TITLE
Adding support for QUIC RETRY token.

### DIFF
--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -220,8 +220,12 @@ bool TestReachability(const ReachConfig& Config) {
             if (Retry) {
               ++Results.RetryCount;
             }
-            if (Config.PrintStatistics)
-                printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u %u:%u (%2.1fx)    %4u    %4u    %s     %c     %c",
+            if (Config.PrintStatistics){
+                char HandshakeTags[3] = {
+                    TooMuch ? '!' : (MultiRtt ? '*' : ' '),
+                    Retry ? 'R' : ' ',
+                    '\0'};
+                printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u %u:%u (%2.1fx)    %4u    %4u    %s     %s",
                     Connection.Stats.Rtt / 1000, Connection.Stats.Rtt % 1000,
                     InitialTime / 1000, InitialTime % 1000,
                     HandshakeTime / 1000, HandshakeTime % 1000,
@@ -233,8 +237,8 @@ bool TestReachability(const ReachConfig& Config) {
                     Connection.Stats.HandshakeClientFlight1Bytes,
                     Connection.Stats.HandshakeServerFlight1Bytes,
                     Connection.FamilyString,
-                    TooMuch ? '!' : (MultiRtt ? '*' : ' '),
-                    Retry ? 'R' : ' ');
+                    HandshakeTags);
+            }
         }
         if (Config.PrintStatistics) printf("\n");
     }

--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -49,6 +49,7 @@ struct ReachResults {
     uint32_t ReachableCount {0};
     uint32_t TooMuchCount {0};
     uint32_t MultiRttCount {0};
+    uint32_t RetryCount {0};
 };
 
 bool ParseConfig(int argc, char **argv, ReachConfig& Config) {
@@ -168,13 +169,13 @@ void DumpResultsToFile(const ReachConfig &Config, const ReachResults &Results) {
             return;
         }
     } else {
-        fprintf(File, "UtcDateTime,Total,Reachable,TooMuch,MultiRtt\n");
+        fprintf(File, "UtcDateTime,Total,Reachable,TooMuch,MultiRtt,Retry\n");
     }
     char UtcDateTime[256];
     time_t Time = time(nullptr);
     struct tm* Tm = gmtime(&Time);
     strftime(UtcDateTime, sizeof(UtcDateTime), "%Y.%m.%d-%H:%M:%S", Tm);
-    fprintf(File, "%s,%u,%u,%u,%u\n", UtcDateTime, Results.TotalCount, Results.ReachableCount, Results.TooMuchCount, Results.MultiRttCount);
+    fprintf(File, "%s,%u,%u,%u,%u,%u\n", UtcDateTime, Results.TotalCount, Results.ReachableCount, Results.TooMuchCount, Results.MultiRttCount, Results.RetryCount);
     fclose(File);
     printf("\nOutput written to %s\n", Config.OutputFile);
 }
@@ -208,6 +209,7 @@ bool TestReachability(const ReachConfig& Config) {
             auto InitialTime = (uint32_t)(Connection.Stats.TimingInitialFlightEnd - Connection.Stats.TimingStart);
             auto Amplification = (double)Connection.Stats.RecvTotalBytes / (double)Connection.Stats.SendTotalBytes;
             auto TooMuch = false, MultiRtt = false;
+            auto Retry = (bool)(Connection.Stats.StatelessRetry);
             if (Connection.Stats.SendTotalPackets != 1) {
                 MultiRtt = true;
                 ++Results.MultiRttCount;
@@ -215,8 +217,11 @@ bool TestReachability(const ReachConfig& Config) {
                 TooMuch = Amplification > 3.0;
                 if (TooMuch) ++Results.TooMuchCount;
             }
+            if (Retry) {
+              ++Results.RetryCount;
+            }
             if (Config.PrintStatistics)
-                printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u %u:%u (%2.1fx)    %4u    %4u    %s     %c",
+                printf("    %3u.%03u ms    %3u.%03u ms    %3u.%03u ms    %u:%u %u:%u (%2.1fx)    %4u    %4u    %s     %c     %c",
                     Connection.Stats.Rtt / 1000, Connection.Stats.Rtt % 1000,
                     InitialTime / 1000, InitialTime % 1000,
                     HandshakeTime / 1000, HandshakeTime % 1000,
@@ -228,7 +233,8 @@ bool TestReachability(const ReachConfig& Config) {
                     Connection.Stats.HandshakeClientFlight1Bytes,
                     Connection.Stats.HandshakeServerFlight1Bytes,
                     Connection.FamilyString,
-                    TooMuch ? '!' : (MultiRtt ? '*' : ' '));
+                    TooMuch ? '!' : (MultiRtt ? '*' : ' '),
+                    Retry ? 'R' : ' ');
         }
         if (Config.PrintStatistics) printf("\n");
     }
@@ -242,6 +248,8 @@ bool TestReachability(const ReachConfig& Config) {
                 printf("%4u domain(s) required multiple round trips (*)\n", Results.MultiRttCount);
             if (Results.TooMuchCount)
                 printf("%4u domain(s) exceeded amplification limits (!)\n", Results.TooMuchCount);
+            if (Results.RetryCount)
+                printf("%4u domain(s) sent RETRY packets (R)\n", Results.RetryCount);
         }
     }
 


### PR DESCRIPTION
This extends the live preview with an `R` if the RETRY token was present. The summary printout and write-out into file (`-f`) is also extended to support the RETRY counter.

```
$ ./quicreach google.com,youtube.com,vk.com,vkontakte.ru --stats
                        SERVER           RTT        TIME_I        TIME_H               SEND:RECV      C1      S1    FAMILY
                    google.com     19.217 ms     19.495 ms     47.551 ms    3:7 2520:8264 (3.3x)     269    6801    IPv4     *      
                   youtube.com     21.511 ms     21.768 ms     47.075 ms    3:7 2520:8271 (3.3x)     270    6803    IPv4     *      
                        vk.com     39.500 ms     78.672 ms     79.087 ms    2:6 2520:4412 (1.8x)     265    4046    IPv4     *     R
                  vkontakte.ru     40.664 ms     77.749 ms     78.147 ms    2:6 2520:4413 (1.8x)     271    4047    IPv4     *     R

   4 domain(s) attempted
   4 domain(s) reachable
   4 domain(s) required multiple round trips (*)
   2 domain(s) sent RETRY packets (R)
```