### PR TITLE
Fix code scanning alert no. 213: Use of potentially dangerous function

### DIFF
--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -329,8 +329,9 @@ void DumpResultsToFile() {
     }
     char UtcDateTime[256];
     time_t Time = time(nullptr);
-    struct tm* Tm = gmtime(&Time);
-    strftime(UtcDateTime, sizeof(UtcDateTime), "%Y.%m.%d-%H:%M:%S", Tm);
+    struct tm Tm;
+    gmtime_r(&Time, &Tm);
+    strftime(UtcDateTime, sizeof(UtcDateTime), "%Y.%m.%d-%H:%M:%S", &Tm);
     fprintf(File, "%s,%u,%u,%u,%u,%u,%u,%u,%u\n", UtcDateTime,
         Results.TotalCount.load(), Results.ReachableCount.load(), Results.TooMuchCount.load(), Results.MultiRttCount.load(),
         Results.RetryCount.load(), Results.IPv6Count.load(), Results.Quicv2Count.load(), Results.WayTooMuchCount.load());

--- a/src/quicreach.cpp
+++ b/src/quicreach.cpp
@@ -330,7 +330,11 @@ void DumpResultsToFile() {
     char UtcDateTime[256];
     time_t Time = time(nullptr);
     struct tm Tm;
+#ifdef _WIN32
+    gmtime_s(&Tm, &Time);
+#else
     gmtime_r(&Time, &Tm);
+#endif
     strftime(UtcDateTime, sizeof(UtcDateTime), "%Y.%m.%d-%H:%M:%S", &Tm);
     fprintf(File, "%s,%u,%u,%u,%u,%u,%u,%u,%u\n", UtcDateTime,
         Results.TotalCount.load(), Results.ReachableCount.load(), Results.TooMuchCount.load(), Results.MultiRttCount.load(),


### PR DESCRIPTION
Fixes [https://github.com/microsoft/quicreach/security/code-scanning/213](https://github.com/microsoft/quicreach/security/code-scanning/213)

To fix the problem, we should replace the call to `gmtime` with `gmtime_r`, which is a thread-safe alternative. The `gmtime_r` function requires the caller to provide a `tm` structure where the result will be stored, thus avoiding the use of shared static memory.

- Replace the call to `gmtime` with `gmtime_r`.
- Allocate a `tm` structure on the stack and pass it to `gmtime_r`.
- Update the code to use the stack-allocated `tm` structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
