### PR TITLE
ci: build with Visual Studio 2026 on windows-latest

### DIFF
--- a/.azure/pre-build.ps1
+++ b/.azure/pre-build.ps1
@@ -50,4 +50,4 @@ if ($_Arch -eq "x86") { $_Arch = "Win32" }
 $Shared = "off"
 if ($Link -ne "static") { $Shared = "on" }
 
-Execute "cmake" "-G ""Visual Studio 17 2022"" -A $_Arch -DREACH_ARCH=$_Arch -DREACH_ONEBRANCH=on -DQUIC_TLS_LIB=$Tls -DQUIC_BUILD_SHARED=$Shared .."
+Execute "cmake" "-G ""Visual Studio 18 2026"" -A $_Arch -DREACH_ARCH=$_Arch -DREACH_ONEBRANCH=on -DQUIC_TLS_LIB=$Tls -DQUIC_BUILD_SHARED=$Shared .."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,6 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       with:
         submodules: 'recursive'
-    - name: Install Perl
-      if: runner.os == 'Windows'
-      uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6
-      with:
-        perl-version: '5.34'
     - name: Install NASM
       if: runner.os == 'Windows'
       uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b

--- a/.github/workflows/reach.yml
+++ b/.github/workflows/reach.yml
@@ -54,7 +54,7 @@ jobs:
         fetch-depth: 0
         submodules: 'recursive'
     - name: Generate
-      run: mkdir build && cd build && cmake -G 'Visual Studio 17 2022' -A x64 -DQUIC_TLS_LIB=schannel ..
+      run: mkdir build && cd build && cmake -G 'Visual Studio 18 2026' -A x64 -DQUIC_TLS_LIB=schannel ..
     - name: Build
       run: cd build && cmake --build . --config Debug
     - name: Install

--- a/build.ps1
+++ b/build.ps1
@@ -53,7 +53,7 @@ if ($IsWindows) {
 
     $_Arch = $Arch
     if ($_Arch -eq "x86") { $_Arch = "Win32" }
-    Execute "cmake" "-G ""Visual Studio 17 2022"" -A $_Arch -DREACH_ARCH=$Arch -DQUIC_TLS_LIB=$Tls -DQUIC_BUILD_SHARED=$Shared .."
+    Execute "cmake" "-G ""Visual Studio 18 2026"" -A $_Arch -DREACH_ARCH=$Arch -DQUIC_TLS_LIB=$Tls -DQUIC_BUILD_SHARED=$Shared .."
     Execute "cmake" "--build . --config $Config"
 
     if ($BuildInstaller) {


### PR DESCRIPTION
Upgrades the Windows CI build paths to use the Visual Studio 2026 CMake generator (`Visual Studio 18 2026`) instead of `Visual Studio 17 2022`.

### Changes
- `build.ps1` — Windows build generator
- `.azure/pre-build.ps1` — OneBranch-style Windows build generator
- `.github/workflows/reach.yml` — Windows-Schannel reachability job generator

All affected jobs run on `windows-latest`.