### PR TITLE
Group action upgrade in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "saturday"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"


### PR DESCRIPTION
Have dependabot upgrade all actions in one PR.
This will avoid CI issue with dependent actions (like CodeQL ones).

Also change the schedule to Saturdays to align with other projects.